### PR TITLE
fix: Add missed reference in RenameSolution.ps1

### DIFF
--- a/RenameSolution.ps1
+++ b/RenameSolution.ps1
@@ -77,6 +77,7 @@ Write-Host $msg
 $landed = $Name + " has landed"
 ((Get-Content -path ..\$Name\$Name\$Name.cs -Raw) -replace 'ModStub has landed',$landed) | Set-Content -Path ..\$Name\$Name\$Name.cs 
 ((Get-Content -path ..\$Name\$Name\$Name.csproj -Raw) -replace 'JotunnModStub',$Name) | Set-Content -Path ..\$Name\$Name\$Name.csproj
+((Get-Content -path ..\$Name\$Name\$Name.csproj -Raw) -replace 'JotunnModUnity',$unity) | Set-Content -Path ..\$Name\$Name\$Name.csproj
 ((Get-Content -path ..\$Name\$Name\Properties\AssemblyInfo.cs -Raw) -replace 'JotunnModStub',$Name) | Set-Content -Path ..\$Name\$Name\Properties\AssemblyInfo.cs
 
 


### PR DESCRIPTION
Apologies if I'm misunderstanding something here, I'm new to modding Valheim and was just following the [Asset Creation](https://valheim-modding.github.io/Jotunn/tutorials/asset-creation.html) tutorial when I noticed this. My DLLs weren't getting moved across after building.

$(UNITY_FOLDER) is used during `CopyToUnity` to copy DLLs from the vanilla/ripped location into the mod. It is missed during RenameSolution.ps1