### PR TITLE
Update debug & release publish scripts

### DIFF
--- a/publish_debug.sh
+++ b/publish_debug.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DLL=JotunnModStub/bin/Debug/JotunnModStub.dll
+DLL=JotunnModStub/bin/Debug/net48/JotunnModStub.dll
 PLUGINS=/home/$USER/.local/share/Steam/steamapps/common/Valheim/BepInEx/plugins
 
 # Check that source files exist and are readable

--- a/publish_release.sh
+++ b/publish_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DLL=JotunnModStub/bin/Release/JotunnModStub.dll
+DLL=JotunnModStub/bin/Release/net48/JotunnModStub.dll
 PLUGINS=JotunnModStub/Package/plugins
 README=README.md
 #TRANSLATIONS=Translations


### PR DESCRIPTION
Update to correct the filepath for the DLL variable in both publish scripts. Building the project drops the files in /Debug/net48, /Release/net48, respectively. 