### PR TITLE
Fix Incorrect Unity Project Path Reference in RenameSolution.ps1

### DIFF
--- a/scripts/RenameSolution.ps1
+++ b/scripts/RenameSolution.ps1
@@ -60,7 +60,7 @@ if ($Name -ne "")
 Write-Host "     . . . Renaming files and folders to '$Name' . . ."
 Move-Item -Path ..\$Name\JotunnModStub -Destination ..\$Name\$Name
 $unity = $Name + "Unity"
-Move-Item -Path ..\$Name\JotunnModUnity -Destination ..\$Name\$unity
+Move-Item -Path ..\$Name\JotunnModStubUnity -Destination ..\$Name\$unity
 Get-ChildItem -Path ..\$Name\ -File -Recurse | % -Process{if($_.Name -ne "JotunnModStub.zip") {Rename-Item -Path $_.PSPath -NewName $_.Name.replace("JotunnModStub", $Name)}}
 }
 else{
@@ -77,7 +77,7 @@ Write-Host $msg
 $landed = $Name + " has landed"
 ((Get-Content -path ..\$Name\$Name\$Name.cs -Raw) -replace 'ModStub has landed',$landed) | Set-Content -Path ..\$Name\$Name\$Name.cs 
 ((Get-Content -path ..\$Name\$Name\$Name.csproj -Raw) -replace 'JotunnModStub',$Name) | Set-Content -Path ..\$Name\$Name\$Name.csproj
-((Get-Content -path ..\$Name\$Name\$Name.csproj -Raw) -replace 'JotunnModUnity',$unity) | Set-Content -Path ..\$Name\$Name\$Name.csproj
+((Get-Content -path ..\$Name\$Name\$Name.csproj -Raw) -replace 'JotunnModStubUnity',$unity) | Set-Content -Path ..\$Name\$Name\$Name.csproj
 ((Get-Content -path ..\$Name\$Name\Properties\AssemblyInfo.cs -Raw) -replace 'JotunnModStub',$Name) | Set-Content -Path ..\$Name\$Name\Properties\AssemblyInfo.cs
 
 


### PR DESCRIPTION
RenameSolution.ps1 uses an incorrect or outdated reference to the Unity project path when attempting to rename items. Instead of renaming the `JotunnModStubUnity` folder, it was attempting (and failing) to rename `JotunnModUnity`, which was causing:
1. The Unity project folder name to never get changed
2. The solution's post-build tasks to fail, as it was trying to copy game assemblies to a non-existent Unity project path